### PR TITLE
add PlatformIO configuration

### DIFF
--- a/GraphicsTest/.gitignore
+++ b/GraphicsTest/.gitignore
@@ -1,0 +1,6 @@
+.pio
+.vscode
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/GraphicsTest/board/esp32-s3-0.42oled.json
+++ b/GraphicsTest/board/esp32-s3-0.42oled.json
@@ -1,0 +1,38 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "partitions": "default.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32S3_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [["0x239A", "0x811B"]],
+    "mcu": "esp32s3",
+    "variant": "esp32s3"
+  },
+  "connectivity": ["bluetooth", "wifi"],
+  "debug": {
+    "default_tool": "esp-builtin",
+    "onboard_tools": ["esp-builtin"],
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": ["arduino", "espidf"],
+  "name": "ESP32 S3 0.42 OLED (4 MB QD, 2MB PSRAM)",
+  "upload": {
+    "flash_size": "4MB",
+    "maximum_ram_size": 532480,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html",
+  "vendor": "Espressif"
+}

--- a/GraphicsTest/platformio.ini
+++ b/GraphicsTest/platformio.ini
@@ -1,0 +1,25 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[platformio]
+name = ESP32-S3 with 0.42 OLED
+description = factory firmware
+boards_dir = ./board
+src_dir = .
+
+[env:esp32-s3-0.42oled]
+platform = espressif32
+board = esp32-s3-0.42oled
+framework = arduino
+upload_speed = 921600
+lib_ldf_mode = deep+
+lib_deps = 
+	kitesurfer1404/WS2812FX@^1.4.1
+	olikraus/U8g2@^2.34.15


### PR DESCRIPTION
This PR is related to #3.

This is a working integration for PlatformIO for the factory project. It will create the [default partitions](https://github.com/espressif/arduino-esp32/blob/master/tools/partitions/default.csv).

I couldn't find any information about the onboard RAM, so I used 520KB for it. The compiled code will be checked while compile time and printed out to the console. For the GraphicsTest the result is

```
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [          ]   4.2% (used 22280 bytes from 532480 bytes)
Flash: [==        ]  24.4% (used 319861 bytes from 1310720 bytes)
```